### PR TITLE
Fixes incl config file format change

### DIFF
--- a/TagTracker.py
+++ b/TagTracker.py
@@ -1,6 +1,4 @@
 # TagTracker by Julias Hocking
-# FIXME: this uses all_tags as the master list of allowable tags.
-# Should use valid_tags instead? (valid_tags is all_tags less retired_tags)
 #
 
 import os
@@ -447,8 +445,9 @@ def edit_entry(target = False, in_or_out = False, new_time = False):
                 if new_time == False:
                     iprint('Invalid time entered (cancelled edit).')
                 elif in_or_out == 'i':
-                    if (time_str_to_minutes(new_time) >
-                            time_str_to_minutes(check_outs[target])):
+                    if target in check_outs and \
+                        (time_str_to_minutes(new_time) >
+                        time_str_to_minutes(check_outs[target])):
                         iprint("Can't set a check-IN later than a check-OUT;")
                         iprint(f"{target} checked OUT at {check_outs[target]}")
                     else:
@@ -547,7 +546,9 @@ def tag_check(tag:str) -> None:
 
     This processes a prompt that's just a tag ID.
     """
-    if not tag in cfg.retired_tags:
+    if tag in cfg.retired_tags: # if retired print specific retirement message
+        iprint(f"{tag} is retired.")
+    else: # must not be retired so handle as normal
         checked_in = tag in check_ins
         checked_out = tag in check_outs
         if checked_in:
@@ -580,8 +581,7 @@ def tag_check(tag:str) -> None:
         else:# if string is in neither dict
             check_ins[tag] = get_time()# check it in
             iprint(f"{tag} checked IN")
-    else: # must be retired
-        iprint(f"{tag} is retired.")
+    
 
 def process_prompt(prompt:str) -> None:
     """Process one user-input command.

--- a/TagTracker.py
+++ b/TagTracker.py
@@ -47,7 +47,7 @@ def canonical_tag( maybe_tag:str ) -> str|None:
         return f"{r.group(1).lower()}{r.group(2)}"
     return None
 
-def valid_tag( tag:str ) ->bool:
+def valid_tag( tag:str ) -> bool:
     """Return whether 'tag' simplifies to a valid [known] tag."""
     #FIXME: this is not used yet
     return bool(canonical_tag( tag ) in cfg.all_tags)
@@ -66,7 +66,7 @@ def read_tags() -> bool:
     if none exists, make one.
     """
     #FIXME: Refactor
-    pathlib.Path("logs").mkdir(exist_ok = True) # make logs folder if none exists
+    pathlib.Path("logs").mkdir(exist_ok = True) # make logs folder if missing
     global check_ins, check_outs
     check_ins = {} # check in dictionary tag:time
     check_outs = {} # check out dictionary tag:time
@@ -76,6 +76,10 @@ def read_tags() -> bool:
             line = f.readline() # read check ins header
             line = f.readline() # read first tag entry if exists
             line_counter = 2 # track line number
+
+            # FIXME: below check for the line being a tag should 
+            # probably be based on cfg.valid_tags or canonical_tag()
+            # rather than the first character being 'B'
             while line[0] != 'B': # while the first chr of each line isn't a header
                 cells = line.rstrip().split(',')
                 # if either a tag or time is invalid...
@@ -242,9 +246,9 @@ def show_stats():
     norm = 0 # counting bikes by type
     over = 0
     for tag in check_ins:
-        if tag in cfg.norm_tags:
+        if tag in cfg.normal_tags:
             norm += 1
-        elif tag in cfg.over_tags:
+        elif tag in cfg.oversize_tags:
             over += 1
     tot_in = norm + over
 
@@ -549,10 +553,8 @@ def tag_check(tag:str) -> None:
     if tag in cfg.retired_tags: # if retired print specific retirement message
         iprint(f"{tag} is retired.")
     else: # must not be retired so handle as normal
-        checked_in = tag in check_ins
-        checked_out = tag in check_outs
-        if checked_in:
-            if checked_out:# if string is in checked_in AND in checked_out
+        if tag in check_ins:
+            if tag in check_outs:# if string is in checked_in AND in checked_out
                 query_tag(tag)
                 iprint(f"Overwrite {check_outs[tag]} check-out with "
                        f"current time ({get_time()})? (y/N)")
@@ -562,7 +564,7 @@ def tag_check(tag:str) -> None:
                             new_time = get_time())
                 else:
                     iprint("Cancelled")
-            else:
+            else:# checked in only
                 now_mins = time_str_to_minutes(get_time())
                 check_in_mins = time_str_to_minutes(check_ins[tag])
                 time_diff_mins = now_mins - check_in_mins
@@ -581,7 +583,7 @@ def tag_check(tag:str) -> None:
         else:# if string is in neither dict
             check_ins[tag] = get_time()# check it in
             iprint(f"{tag} checked IN")
-    
+
 
 def process_prompt(prompt:str) -> None:
     """Process one user-input command.
@@ -648,15 +650,19 @@ def main() -> None:
     main() # loop
 
 # STARTUP
-check_ins = {}
-check_outs = {}
+if not cfg.SETUP_PROBLEM: # no issue flagged while reading config
+    check_ins = {}
+    check_outs = {}
 
-print(f"TagTracker {cfg.VERSION} by Julias Hocking")
-DATE = get_date()
-LOG_FILEPATH = f"logs/{cfg.LOG_BASENAME}{DATE}.log"
+    print(f"TagTracker {cfg.VERSION} by Julias Hocking")
+    DATE = get_date()
+    LOG_FILEPATH = f"logs/{cfg.LOG_BASENAME}{DATE}.log"
 
-if read_tags(): # only run main() if tags read successfully
-    main()
-else: # if read_tags() problem
+    if read_tags(): # only run main() if tags read successfully
+        main()
+    else: # if read_tags() problem
+        print(f"\n{cfg.INDENT}Closing automatically in 30 seconds...")
+        time.sleep(30)
+else:
     print(f"\n{cfg.INDENT}Closing automatically in 30 seconds...")
     time.sleep(30)

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -78,8 +78,6 @@ retired_tags = [line.rstrip().split()[0] for line in lines if not line in ['', '
 
 # combine allowable tags into single list for brevity in main script
 all_tags = norm_tags + over_tags
-valid_tags = [tag for tag in all_tags if not tag in retired_tags]
-
 
 if not Path("Tag Colour Abbreviations.cfg").is_file(): # make new retired tags file if none yet exists
     with open('Tag Colour Abbreviations.cfg', 'w') as f:

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -1,8 +1,12 @@
 # Config for TagTracker by Julias Hocking
-from pathlib import Path
+import os
+import re
 
 # Basename for the Logfiles. They will be {BASENAME}YY-MM-DD.LOG.
 LOG_BASENAME = "cityhall_"
+
+# regular expression for tag name format
+TAG_NAME_REGEX = "^ *[a-zA-Z][a-zA-Z]*[0-9][0-9]* *$"
 
 # time cutoffs for stays under x time and over y time
 T_UNDER = 1.5*60 # minutes
@@ -31,7 +35,7 @@ quit_kws = ['quit','exit','stop','x','bye']
 del_kws = ['del','delete','d']
 
 # keywords to query a tag
-query_kws = ['query','q','?', '/']
+query_kws = ['query','q','?','/']
 
 # editing
 edit_kws = ['edit','e','ed']
@@ -50,40 +54,54 @@ help_message = f"""{INDENT}List these commands     :   help  /  h
 {INDENT}*using this isn't important; data is autosaved"""
 
 # assemble list of normal tags
-if not Path("Normal Tags.cfg").is_file(): # make new normal tags file if none yet exists
-    with open('Normal Tags.cfg', 'w') as f:
-        header = "Enter each NORMAL tag on its own line, separating any comments with whitespace eg 'wa4 comment'\n"
-        f.writelines(header)
-with open('Normal Tags.cfg', 'r') as f:
-    lines = f.readlines()[1:] # ignore header text
-norm_tags = [line.rstrip().split()[0] for line in lines if not line in ['', '\n']]
+def build_tags_config(filename:str) -> list[str] | None:
+    """Build a tag list from a file.
+    
+    Constructs a list of each allowable tag in a given category
+    (normal, oversize, retired, etc) by reading its category.cfg file.
+    """
+    tags = []
+    if not os.path.exists(filename): # make new tags config file if needed
+        with open(filename, 'w') as f:
+            header = "# Enter lines of whitespace-separated tags, \
+eg 'wa0 wa1 wa2 wa3'\n"
+            f.writelines(header)
+    with open(filename, 'r') as f: # open and read
+        lines = f.readlines()
+    line_counter = 0 # init line counter to 0
+    for line in lines:
+        line_counter += 1 # increment for current line
+        if not line[0] == '#': # for each non-comment line 
+            # (blank lines do nothing here anyway)
+            line_words = line.rstrip().split() # split into each tag name
+            for word in line_words: # check line for nonconforming tag names
+                if not re.match(TAG_NAME_REGEX, word):
+                    print(f'Invalid tag "{word}" found \
+in {filename} on line {line_counter}')
+                    return None # stop loading
+            tags += line_words # add all tags in that line to this tag type
+    return tags
 
-# assemble list of oversize tags
-if not Path("Oversize Tags.cfg").is_file(): # make new oversize tags file if none yet exists
-    with open('Oversize Tags.cfg', 'w') as f:
-        header = "Enter each OVERSIZE tag on its own line, separating any comments with whitespace eg 'be4 comment'\n"
-        f.writelines(header)
-with open('Oversize Tags.cfg', 'r') as f:
-    lines = f.readlines()[1:] # ignore header text
-over_tags = [line.rstrip().split()[0] for line in lines if not line in ['', '\n']]
+normal_tags   = build_tags_config('normal_tags.cfg')
 
-# assemble list of retired tags
-if not Path("Retired Tags.cfg").is_file(): # make new retired tags file if none yet exists
-    with open('Retired Tags.cfg', 'w') as f:
-        header = "Enter each RETIRED tag on its own line with no punctuation, separating any comments with whitespace eg 'wa4 lost/damaged/etc'\n"
-        f.writelines(header)
-with open('Retired Tags.cfg', 'r') as f:
-    lines = f.readlines()[1:] # ignore header text
-retired_tags = [line.rstrip().split()[0] for line in lines if not line in ['', '\n']]
+oversize_tags = build_tags_config('oversize_tags.cfg')
+
+retired_tags  = build_tags_config('retired_tags.cfg')
 
 # combine allowable tags into single list for brevity in main script
-all_tags = norm_tags + over_tags
+try:
+    all_tags = normal_tags + oversize_tags
+    SETUP_PROBLEM = False # don't flag because it's fine
+except TypeError: # if returned None for any of these tags lists
+    # flag problem for main script
+    SETUP_PROBLEM = "Unsuccessful load of config files;" 
 
-if not Path("Tag Colour Abbreviations.cfg").is_file(): # make new retired tags file if none yet exists
-    with open('Tag Colour Abbreviations.cfg', 'w') as f:
-        header = "Enter each first letter(s) of a tag name corresponding to a tag colour separated by whitespace on its own line, eg 'b black' etc"
+if not os.path.exists("tag_colour_abbreviations.cfg"):
+    with open('tag_colour_abbreviations.cfg', 'w') as f:
+        header = "Enter each first letter(s) of a tag name corresponding \
+to a tag colour separated by whitespace on their own line, eg 'b black' etc"
         f.writelines(header)
-with open('Tag Colour Abbreviations.cfg', 'r') as f:
+with open('tag_colour_abbreviations.cfg', 'r') as f:
     lines = f.readlines()[1:] # ignore header text
 colour_letters = {}
 for line in lines:
@@ -95,6 +113,6 @@ for line in lines:
 
 # pull startup header and version from changelog
 with open('changelog.txt', 'r') as f:
-    f.readline()#[:-1] # cut off '\n'
-    f.readline() # skip empty line
+    f.readline()
+    f.readline() # skip empty lines
     VERSION = f.readline()[:-2] # cut off ':\n'


### PR DESCRIPTION
TrackerConfig:
- Changed tag config file formats about as outlined in #13 -- RegEx used was slightly different (^ *[a-zA-Z][a-zA-Z]*[0-9][0-9]* *$) to allow for extant tags to are numbered with only zeroes
- Moved building tag config lists to its own function to eliminate repeat code -- if there's a problem reading the configs it's flagged so the main script doesn't try to keep starting
- Some linting for line lengths
- Removed valid tags -- see below

TagTracker:
- Startup process now only runs if no problem flagged during config read -- see above
- Squashed a bug (#31) causing a crash when editing a tag with only a check-in recorded 
- Removed some trailing whitespace
- Removed cfg.valid_tags as a thing because it's redundant -- if we're ever checking for a retired tag it's probably clearer to just use cfg.retired_tags which has to exist anyways
- Other minor changes I forget