### PR TITLE
Lint-cleanup

### DIFF
--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -76,8 +76,8 @@ def build_tags_config(filename:str) -> list[str] | None:
             line_words = line.rstrip().split() # split into each tag name
             for word in line_words: # check line for nonconforming tag names
                 if not re.match(TAG_NAME_REGEX, word):
-                    print(f'Invalid tag "{word}" found \
-in {filename} on line {line_counter}')
+                    print(f'Invalid tag "{word}" found '
+                          f'in {filename} on line {line_counter}')
                     return None # stop loading
             tags += line_words # add all tags in that line to this tag type
     return tags

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -63,15 +63,15 @@ def build_tags_config(filename:str) -> list[str] | None:
     tags = []
     if not os.path.exists(filename): # make new tags config file if needed
         with open(filename, 'w') as f:
-            header = "# Enter lines of whitespace-separated tags, \
-eg 'wa0 wa1 wa2 wa3'\n"
+            header = "# Enter lines of whitespace-separated tags, "
+            "eg 'wa0 wa1 wa2 wa3'\n"
             f.writelines(header)
     with open(filename, 'r') as f: # open and read
         lines = f.readlines()
     line_counter = 0 # init line counter to 0
     for line in lines:
         line_counter += 1 # increment for current line
-        if not line[0] == '#': # for each non-comment line 
+        if not line[0] == '#': # for each non-comment line
             # (blank lines do nothing here anyway)
             line_words = line.rstrip().split() # split into each tag name
             for word in line_words: # check line for nonconforming tag names
@@ -94,12 +94,13 @@ try:
     SETUP_PROBLEM = False # don't flag because it's fine
 except TypeError: # if returned None for any of these tags lists
     # flag problem for main script
-    SETUP_PROBLEM = "Unsuccessful load of config files;" 
+    SETUP_PROBLEM = "Unsuccessful load of config files;"
 
 if not os.path.exists("tag_colour_abbreviations.cfg"):
     with open('tag_colour_abbreviations.cfg', 'w') as f:
-        header = "Enter each first letter(s) of a tag name corresponding \
-to a tag colour separated by whitespace on their own line, eg 'b black' etc"
+        header = ("Enter each first letter(s) of a tag name corresponding to "
+                  "a tag colour separated by whitespace on their own line, "
+                  "eg 'b black' etc")
         f.writelines(header)
 with open('tag_colour_abbreviations.cfg', 'r') as f:
     lines = f.readlines()[1:] # ignore header text


### PR DESCRIPTION
Mostly line length fixes plus removed unused do_printing argument in query_tag and its unused str returns. 

(These were originally to be for checking a tag's status within other functions, but I now think it would be better to either leave the other functions just checking the tags' statuses directly, or completely redo that whole deal with some kind of get_status() method with the implementation of stay/tag/bike class objects)