### PR TITLE
Improved audit report format (#24)

### DIFF
--- a/TagTracker.py
+++ b/TagTracker.py
@@ -501,7 +501,7 @@ def count_colours(inv:list[str]) -> str:
     in a given list, and return results as a str. Probably avoid calling
     this on empty lists
     """
-    # FIXME: test for and handle empty list passed-in
+    # FIXME: this function no longer required, replaced by audit_report()
     just_colour_abbreviations = []
     for tag in inv: # shorten tags to just their colours
         shortened = ''

--- a/TagTracker.py
+++ b/TagTracker.py
@@ -560,7 +560,7 @@ def audit_report(as_of_when:str|int=None) -> None:
         cfg.normal_tags
         cfg.oversize_tags
     """
-    # FIXME: this is long and could get broken up
+    # FIXME: this is long and could get broken up with helper functions
 
     rightnow = get_time()
     # What time will this audit report reflect?

--- a/TagTracker.py
+++ b/TagTracker.py
@@ -540,7 +540,9 @@ def tags_by_prefix(tags_dict:dict) -> dict:
 
     prefixes = {}
     for tag in tags_dict:
-        (prefix,t_number) = cfg.PARSE_TAG_PREFIX_RE.match(tag).groups()
+        #(prefix,t_number) = cfg.PARSE_TAG_PREFIX_RE.match(tag).groups()
+        (t_colour,t_letter,t_number) = parse_tag(tag,test_availability=False)[1:4]
+        prefix = f"{t_colour}{t_letter}"
         if prefix not in prefixes:
             prefixes[prefix] = []
         prefixes[prefix].append(int(t_number))

--- a/TagTracker.py
+++ b/TagTracker.py
@@ -304,8 +304,9 @@ def show_stats():
         hrs_under = f"{(cfg.T_UNDER / 60):3.1f}" # in hours for print clarity
         hrs_over = f"{(cfg.T_OVER / 60):3.1f}"
 
-        iprint(f"\nSummary statistics as of {get_time()} "
-               f"with {len(check_ins)-len(check_outs)} bikes still on hand:\n")
+        print()
+        iprint("Summary statistics "
+               f"({len(check_ins)-len(check_outs)} bikes still on hand):\n")
         iprint(f"Total bikes:    {tot_in:3d}")
         iprint(f"AM bikes:       {AM_ins:3d}")
         iprint(f"PM bikes:       {PM_ins:3d}")

--- a/TagTracker.py
+++ b/TagTracker.py
@@ -55,7 +55,6 @@ def fix_hhmm(inp:str) -> str:
     # Return 5-digit time string
     return f"{h:02d}:{m:02d}"
 
-PARSE_TAG_RE = None
 def parse_tag( maybe_tag:str, test_availability=False ) -> str|None:
     """Test maybe_tag as a tag, return it as tag and bits.
 
@@ -75,13 +74,8 @@ def parse_tag( maybe_tag:str, test_availability=False ) -> str|None:
         tag_number: a sequence number, without lead zeroes.
     """
 
-    # Compile the tagid re only once
-    global PARSE_TAG_RE
-    if not PARSE_TAG_RE:
-        PARSE_TAG_RE = re.compile( r"^ *([a-z]+)([a-z])0*([1-9][0-9]*) *")
-
     maybe_tag = maybe_tag.lower()
-    if not bool(r := PARSE_TAG_RE.match(maybe_tag)):
+    if not bool(r := cfg.PARSE_TAG_RE.match(maybe_tag)):
         return []
 
     tag_colour = r.group(1)
@@ -496,7 +490,7 @@ def edit_entry(target = False, in_or_out = False, new_time = False):
                 if new_time == False:
                     iprint('Invalid time entered (cancelled edit).')
                 elif in_or_out == 'i':
-                    if (target in check_outs and 
+                    if (target in check_outs and
                             (time_str_to_minutes(new_time) >
                             time_str_to_minutes(check_outs[target]))):
                         iprint("Can't set a check-IN later than a check-OUT;")

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -56,7 +56,7 @@ help_message = f"""{INDENT}List these commands     :   help  /  h
 # assemble list of normal tags
 def build_tags_config(filename:str) -> list[str] | None:
     """Build a tag list from a file.
-    
+
     Constructs a list of each allowable tag in a given category
     (normal, oversize, retired, etc) by reading its category.cfg file.
     """
@@ -117,3 +117,6 @@ with open('changelog.txt', 'r') as f:
     f.readline()
     f.readline() # skip empty lines
     VERSION = f.readline()[:-2] # cut off ':\n'
+
+# Regular expression for parsing tags.
+PARSE_TAG_RE = re.compile( r"^ *([a-z]+)([a-z])0*([0-9]+) *$")

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -5,8 +5,11 @@ import re
 # Basename for the Logfiles. They will be {BASENAME}YY-MM-DD.LOG.
 LOG_BASENAME = "cityhall_"
 
-# regular expression for tag name format
-TAG_NAME_REGEX = "^ *[a-zA-Z][a-zA-Z]*[0-9][0-9]* *$"
+# Regular expression for parsing tags -- here & in main program.
+PARSE_TAG_RE = re.compile( r"^ *([a-z]+)([a-z])0*([0-9]+) *$")
+# Regex to pull apart prefix and number on a tag that is already in
+# canonical form (e.g. be7 or wa0 or puf13)
+PARSE_TAG_PREFIX_RE = re.compile( "([a-z]+)([0-9]+)")
 
 # time cutoffs for stays under x time and over y time
 T_UNDER = 1.5*60 # minutes
@@ -75,7 +78,7 @@ def build_tags_config(filename:str) -> list[str] | None:
             # (blank lines do nothing here anyway)
             line_words = line.rstrip().split() # split into each tag name
             for word in line_words: # check line for nonconforming tag names
-                if not re.match(TAG_NAME_REGEX, word):
+                if not PARSE_TAG_RE.match(word):
                     print(f'Invalid tag "{word}" found '
                           f'in {filename} on line {line_counter}')
                     return None # stop loading
@@ -118,5 +121,3 @@ with open('changelog.txt', 'r') as f:
     f.readline() # skip empty lines
     VERSION = f.readline()[:-2] # cut off ':\n'
 
-# Regular expression for parsing tags.
-PARSE_TAG_RE = re.compile( r"^ *([a-z]+)([a-z])0*([0-9]+) *$")

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -7,9 +7,6 @@ LOG_BASENAME = "cityhall_"
 
 # Regular expression for parsing tags -- here & in main program.
 PARSE_TAG_RE = re.compile( r"^ *([a-z]+)([a-z])0*([0-9]+) *$")
-# Regex to pull apart prefix and number on a tag that is already in
-# canonical form (e.g. be7 or wa0 or puf13)
-PARSE_TAG_PREFIX_RE = re.compile( "([a-z]+)([0-9]+)")
 
 # time cutoffs for stays under x time and over y time
 T_UNDER = 1.5*60 # minutes

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -57,7 +57,7 @@ help_message = f"""{INDENT}List these commands     :   help  /  h
 {INDENT}*using this isn't important; data is autosaved"""
 
 # assemble list of normal tags
-def build_tags_config(filename:str) -> list[str] | None:
+def build_tags_config(filename:str) -> list[str]:
     """Build a tag list from a file.
 
     Constructs a list of each allowable tag in a given category

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -1,4 +1,5 @@
-# Config for TagTracker by Julias Hocking
+"""Config for TagTracker by Julias Hocking."""
+
 import os
 import re
 
@@ -63,8 +64,8 @@ def build_tags_config(filename:str) -> list[str]:
     tags = []
     if not os.path.exists(filename): # make new tags config file if needed
         with open(filename, 'w') as f:
-            header = "# Enter lines of whitespace-separated tags, "
-            "eg 'wa0 wa1 wa2 wa3'\n"
+            header = ("# Enter lines of whitespace-separated tags, "
+                    "eg 'wa0 wa1 wa2 wa3'\n")
             f.writelines(header)
     with open(filename, 'r') as f: # open and read
         lines = f.readlines()
@@ -111,10 +112,8 @@ for line in lines:
         colour = line.rstrip().split()[1]
         colour_letters[abbrev] = colour # add to dictionary
 
-
 # pull startup header and version from changelog
 with open('changelog.txt', 'r') as f:
     f.readline()
     f.readline() # skip empty lines
     VERSION = f.readline()[:-2] # cut off ':\n'
-


### PR DESCRIPTION
New audit report function (old one still there but does not get called). #24 

New audit report optionally takes a time of day 

Removes unused minutes_to_time_str_list function

Fixed docstring in fix_hhmm

Removes 3.10-style type hints (e.g. str|int)

Allows iprint() to have no text; and optional line_end flag

Fix () error ca. l 66 in config file (#44)
