### PR TITLE
Feat/12/dispatcher

### DIFF
--- a/TagTracker.py
+++ b/TagTracker.py
@@ -899,7 +899,7 @@ def main():
                 query_tag( args )
             case "stats":
                 show_stats()
-            case cfg.NO_COMMAND:
+            case cfg.BAD_COMMAND:
                 iprint( "Unrecognized tag or command.")
                 iprint( "Enter 'h' for help.")
             case _:

--- a/TagTracker.py
+++ b/TagTracker.py
@@ -417,8 +417,7 @@ def show_stats():
 
 def delete_entry(args:list[str]) -> None:
     """Perform tag entry deletion dialogue."""
-    args = args + [None,None,None]
-    (target,which_to_del,confirm) = args[:3]
+    (target,which_to_del,confirm) = (args + [None,None,None])[:3]
     if target:
         target = fix_tag(target,must_be_available=False)
     if not target:
@@ -496,8 +495,7 @@ def delete_entry(args:list[str]) -> None:
                    "can't delete a nonexistent check-out.")
 
 def query_tag(args:list[str]) -> None:
-    args = args + [None]
-    target = args[0]
+    target = (args + [None])[0]
 
     """Query the check in/out times of a specific tag."""
     if not target: # only do dialog if no target passed
@@ -536,8 +534,7 @@ def prompt_for_time(inp = False) -> bool or str:
 
 def edit_entry(args:list[str]):
     """Perform Dialog to correct a tag's check in/out time."""
-    args = args + [None,None,None]
-    (target, in_or_out, new_time) = args[:3]
+    (target, in_or_out, new_time) = (args + [None,None,None])[:3]
 
     edit_syntax_message = ("Syntax: e <bike's tag> <in or out (i/o)> "
             "<new time or 'now'>")
@@ -662,8 +659,7 @@ def audit_report(args:list[str]) -> None:
     """
     # FIXME: this is long and could get broken up with helper functions
     rightnow = get_time()
-    args = args + [rightnow]
-    as_of_when = args[0]
+    as_of_when = (args + [rightnow])[0]
 
     # What time will this audit report reflect?
     as_of_when = fix_hhmm(as_of_when)
@@ -849,7 +845,7 @@ def tag_check(tag:str) -> None:
 def parse_command( user_input:str ) -> list[str]:
     """Parse user's input into list of [tag] or [command, command args].
 
-      Returns [] if not unrecognized command.
+      Returns [] if not a recognized tag or command.
       """
     input_tokens = user_input.lower().strip().split()
     if not input_tokens:
@@ -858,15 +854,16 @@ def parse_command( user_input:str ) -> list[str]:
     command = fix_tag( input_tokens[0], must_be_available=True)
     if command:
         return [command]    # A tag
-    # cfg.command_aliases is dict of lists of aliases keyed by canonical command name (e.g. {"edit":["ed","e","edi"], etc})
+    # cfg.command_aliases is dict of lists of aliases keyed by
+    # canonical command name (e.g. {"edit":["ed","e","edi"], etc})
     command = None
     for c, aliases in cfg.COMMANDS.items():
         if input_tokens[0] in aliases:
             command = c
             break
-    # Is this an unrecognized command or tag?
+    # Is this an unrecognized command?
     if not command:
-        return [cfg.NO_COMMAND]
+        return [cfg.BAD_COMMAND]
     # We have a recognized command, return it with its args.
     input_tokens[0] = command
     return input_tokens
@@ -916,7 +913,11 @@ def main():
             data_dirty = False
 
 '''
+# This is a model for a potential way to structure do_stuff commands,
+# particularly ones that might prompt for missing args
 def do_edit( args:list[str] ):
+    (target, in_or_out, new_time) = (args + [None,None,None])[:3]
+
     # Action is identified as 'edit'
     tag = get_token( arg[0],optional=False,prompt="Edit what tag?" )
     if not (tag := fix_tag( tag, must_be_available=True)):
@@ -932,7 +933,9 @@ def do_edit( args:list[str] ):
         return
     confirm = get_token( arg[3], optional=False,prompt="Change (Y/n):",default="y')
    (etc)
+'''
 
+'''
 def process_prompt__OLD(prompt:str) -> None:
     """Process one user-input command.
 

--- a/TagTracker.py
+++ b/TagTracker.py
@@ -845,15 +845,19 @@ def tag_check(tag:str) -> None:
 def parse_command( user_input:str ) -> list[str]:
     """Parse user's input into list of [tag] or [command, command args].
 
-      Returns [] if not a recognized tag or command.
-      """
-    input_tokens = user_input.lower().strip().split()
-    if not input_tokens:
+    Returns [] if not a recognized tag or command.
+    """
+    if not (user_input := user_input.lower().strip()):
         return []
-    # Is this a tag?  If so, return it.
+    # Special case - if user input starts with '/' or '?' add a space.
+    if user_input[0] in ["/","?"]:
+        user_input = user_input[0] + " " + user_input[1:]
+    # Split to list, test to see if tag.
+    input_tokens = user_input.split()
     command = fix_tag( input_tokens[0], must_be_available=True)
     if command:
         return [command]    # A tag
+    # See if it is a recognized command.
     # cfg.command_aliases is dict of lists of aliases keyed by
     # canonical command name (e.g. {"edit":["ed","e","edi"], etc})
     command = None

--- a/TagTracker.py
+++ b/TagTracker.py
@@ -867,7 +867,7 @@ def parse_command( user_input:str ) -> list[str]:
             break
     # Is this an unrecognized command?
     if not command:
-        return [cfg.BAD_COMMAND]
+        return [cfg.CMD_UNKNOWN]
     # We have a recognized command, return it with its args.
     input_tokens[0] = command
     return input_tokens
@@ -884,26 +884,26 @@ def main():
         # Dispatcher
         data_dirty = False
         match cmd:
-            case "edit":
+            case cfg.CMD_EDIT:
                 edit_entry( args )
                 data_dirty = True
-            case "audit":
+            case cfg.CMD_AUDIT:
                 audit_report( args )
-            case "delete":
+            case cfg.CMD_DELETE:
                 delete_entry( args )
                 data_dirty = True
-            case "edit":
+            case cfg.CMD_EDIT:
                 edit_entry( args )
                 data_dirty = True
-            case "exit":
+            case cfg.CMD_EXIT:
                 done = True
-            case "help":
+            case cfg.CMD_HELP:
                 print(cfg.help_message)
-            case "query":
+            case cfg.CMD_QUERY:
                 query_tag( args )
-            case "stats":
+            case cfg.CMD_STATS:
                 show_stats()
-            case cfg.BAD_COMMAND:
+            case cfg.CMD_UNKNOWN:
                 iprint( "Unrecognized tag or command.")
                 iprint( "Enter 'h' for help.")
             case _:

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -33,7 +33,7 @@ COMMANDS = {
     "query": ['query','q','?','/'],
     "stats": ['s','stat','stats','sum','summary']
 }
-NO_COMMAND = -1 # special value to mean unrecognized command
+BAD_COMMAND = -1 # special value to mean unrecognized command
 '''
 # FIXME: these are no longer needed.
 # keywords for day end statistics

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -23,24 +23,31 @@ CHECK_OUT_CONFIRM_TIME = 30 # mins
 INDENT = '  '
 CURSOR = '>>> '
 
+# Command keys and aliases.
+COMMANDS = {
+    "audit": ['audit','a','aud'],
+    "delete": ['del','delete','d'],
+    "edit": ['edit','e','ed'],
+    "exit": ['quit','exit','stop','x','bye'],
+    "help": ['help','h'],
+    "query": ['query','q','?','/'],
+    "stats": ['s','stat','stats','sum','summary']
+}
+NO_COMMAND = -1 # special value to mean unrecognized command
+
+# FIXME: these are no longer needed.
 # keywords for day end statistics
 statistics_kws = ['s','stat','stats','sum','summary']
-
 # keywords for audit of logged tags
 audit_kws = ['audit','a','aud']
-
 # keywords to quit the program
 quit_kws = ['quit','exit','stop','x','bye']
-
 # keywords to delete a tag entry
 del_kws = ['del','delete','d']
-
 # keywords to query a tag
 query_kws = ['query','q','?','/']
-
 # editing
 edit_kws = ['edit','e','ed']
-
 # help message
 help_kws = ['help','h']
 
@@ -51,8 +58,8 @@ help_message = f"""{INDENT}List these commands     :   help  /  h
 {INDENT}Edit a time for a tag   :   edit  / e
 {INDENT}Delete a check in/out   :   del   / d
 {INDENT}End of day statistics   :   stat  / s
-{INDENT}Shutdown*               :   stop  / exit / quit / x
-{INDENT}*using this isn't important; data is autosaved"""
+{INDENT}Exit                    :   stop  / exit / quit / x
+"""
 
 # assemble list of normal tags
 def build_tags_config(filename:str) -> list[str]:

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -24,16 +24,15 @@ INDENT = '  '
 CURSOR = '>>> '
 
 # Command keys and aliases.
-COMMANDS = {
-    "audit": ['audit','a','aud'],
-    "delete": ['del','delete','d'],
-    "edit": ['edit','e','ed'],
-    "exit": ['quit','exit','stop','x','bye'],
-    "help": ['help','h'],
-    "query": ['query','q','?','/'],
-    "stats": ['s','stat','stats','sum','summary']
-}
-BAD_COMMAND = -1 # special value to mean unrecognized command
+COMMANDS = {}
+COMMANDS[ CMD_AUDIT := "audit" ] = ['audit','a','aud']
+COMMANDS[ CMD_DELETE := "delete" ] = ['del','delete','d']
+COMMANDS[ CMD_EDIT := "edit" ] = ['edit','e','ed']
+COMMANDS[ CMD_EXIT :="exit" ] = ['quit','exit','stop','x','bye']
+COMMANDS[ CMD_HELP :="help" ] = ['help','h']
+COMMANDS[ CMD_QUERY :="query" ] = ['query','q','?','/']
+COMMANDS[ CMD_STATS :="stats" ] = ['s','stat','stats','sum','summary']
+CMD_UNKNOWN = -1 # special value to mean unrecognized command
 '''
 # FIXME: these are no longer needed.
 # keywords for day end statistics

--- a/TrackerConfig.py
+++ b/TrackerConfig.py
@@ -34,7 +34,7 @@ COMMANDS = {
     "stats": ['s','stat','stats','sum','summary']
 }
 NO_COMMAND = -1 # special value to mean unrecognized command
-
+'''
 # FIXME: these are no longer needed.
 # keywords for day end statistics
 statistics_kws = ['s','stat','stats','sum','summary']
@@ -50,6 +50,7 @@ query_kws = ['query','q','?','/']
 edit_kws = ['edit','e','ed']
 # help message
 help_kws = ['help','h']
+'''
 
 help_message = f"""{INDENT}List these commands     :   help  /  h
 {INDENT}Check in or out         :   <tag name> (eg “wa3”)


### PR DESCRIPTION
This refactors the command processor & dispatcher, to address most of #12 :
- recognition of commands
- definition of command shortcuts in config
- better tolerance of unambiguous but non-canonical  times and tags in prompted parts of edit/delete/query commands
  (more work to be done here)
- interfaces between dispatcher and existing do-stuff functions modified
- main is a loop not a recursion
- main exits cleanly
- main only writes data when it changes

Now-unused functions are commented out but not deleted.

Minor cleanup where stumbled across it.

Changed some of the language printed on screen to emphasize we are in/out bikes not tags (more to be done here)

Future work coming out of this:
- some refactoring of the do-stuff functions to use consistent helper-function on prompts and tag/time recognition
- delete the commented-out functions