### PR TITLE
#106 startup scripts for Win32 and Linux

### DIFF
--- a/startup
+++ b/startup
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Startup script for TagTracker on Linux
+#
+# This will navigate to TagTracker folder, run TagTracker,
+# then (on user confirmation), run it again.  (This because
+# program may well have shut down to reset for next day.)
+
+TT_DIR="$HOME/TagTracker"
+
+this_dir="$(pwd)"
+this_prog=$0
+prog_name="${0##*/}"
+
+echo "Starting TagTracker..."
+echo
+
+cd "$TT_DIR" || exit 1
+python3 tagtracker.py
+echo
+echo "TagTracker done."
+echo
+read -rp "Restart TagTracker? (Y/N): " confirm
+echo
+if [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]]; then
+  exec "$this_prog"
+fi
+# Do not restart
+cd "$this_dir" || exit 1
+echo "To restart TagTracker, enter \"$prog_name\""
+echo

--- a/startup.bat
+++ b/startup.bat
@@ -1,0 +1,4 @@
+@echo off
+%HOMEDRIVE%
+cd %HOMEPATH%\TagTracker
+python tagtracker.py


### PR DESCRIPTION
Created startup (not startup.sh) for Linux, and startup.bat for Windows.
I *think* the execute bit will be set correctly on `startup`.
When TT exits, this prompt about whether to restart, to support overnight-detection-exit, #112 

TagTracker dir will need to be on the PATH

Also, this supersedes the 'startup.sh' command in $HOME on Victoria chromebook, so we will want to remove that.