### PR TITLE
Text tweak

### DIFF
--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -516,8 +516,8 @@ def totals_table(conn: sqlite3.Connection):
         "&nbsp;&nbsp;%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;font-size:0.8rem;'>"
-        f"<i>{explanation_text}</i></td></tr>"
+        f"<tr><td>&nbsp;</td><td colspan='{total_columns-2}' style='text-align:left;padding-top:6px;font-size:0.8rem;'>"
+        f"<i>{explanation_text}</i></td><td>&nbsp;</td></tr>"
     )
 
     print("</table>")

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -518,8 +518,8 @@ def totals_table(conn: sqlite3.Connection):
     print(
         f"<tr><td colspan='{total_columns}'>"
         "<i>%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.</i></td></tr>"
-        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;'>"
-        "<i>%Δ 12mo compares the 12 months prior to today, to the 12 months before that.</i></td></tr>"
+        # f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;'>"
+        # "<i>%Δ 12mo compares the 12 months prior to today, to the 12 months before that.</i></td></tr>"
     )
 
     print("</table>")

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -516,8 +516,8 @@ def totals_table(conn: sqlite3.Connection):
         "&nbsp;&nbsp;%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td>&nbsp;</td><td colspan='{total_columns-2}' style='text-align:left;padding-top:6px;font-size:0.8rem;'>"
-        f"<i>{explanation_text}</i></td><td>&nbsp;</td></tr>"
+        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;font-size:0.8rem;'>"
+        f"<i>{explanation_text}</i></td></tr>"
     )
 
     print("</table>")

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -516,8 +516,10 @@ def totals_table(conn: sqlite3.Connection):
         "%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;font-size:0.8rem;'>"
-        f"<i>{explanation_text}</i></td></tr>"
+        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;'>"
+        "<i>%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.</i></td></tr>"
+        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;'>"
+        "<i>%Δ 12mo compares the 12 months prior to today, to the 12 months before that.</i></td></tr>"
     )
 
     print("</table>")

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -516,8 +516,8 @@ def totals_table(conn: sqlite3.Connection):
         "&nbsp;&nbsp;%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;'>"
-        f"{explanation_text}</td></tr>"
+        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;font-size:0.8rem;'>"
+        f"<i>{explanation_text}</i></td></tr>"
     )
 
     print("</table>")

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -519,7 +519,7 @@ def totals_table(conn: sqlite3.Connection):
         #f"<tr><td colspan='{total_columns}'>"
         #"<i>%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.</i></td></tr>"
         f"<tr><td colspan='{total_columns}'>"
-        "<i>%Δ 12mo compares the 12 months prior to today, to the 12 months before that.</i></td></tr>"
+        "<i>%ΔYTD: compare YTD to same period last year; %Δ12mo: compare most reent 12 months to 12 months before that.</i></td></tr>"
     )
 
     print("</table>")

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -511,15 +511,9 @@ def totals_table(conn: sqlite3.Connection):
         print(html_row(label, ytd_display, pct_ytd, pct_12mo, day_values))
 
     total_columns = 4 + len(display_day_keys)
-    explanation_text = (
-        "%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.  "
-        "%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
-    )
     print(
-        #f"<tr><td colspan='{total_columns}'>"
-        #"<i>%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.</i></td></tr>"
         f"<tr><td colspan='{total_columns}'>"
-        "<i>%ΔYTD: compare YTD to same period last year; %Δ12mo: compare most reent 12 months to 12 months before that.</i></td></tr>"
+        "<i>%ΔYTD compares YTD to same period last year; %Δ12mo compares most reent 12 months to 12 months before that.</i></td></tr>"
     )
 
     print("</table>")

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -513,7 +513,7 @@ def totals_table(conn: sqlite3.Connection):
     total_columns = 4 + len(display_day_keys)
     print(
         f"<tr><td colspan='{total_columns}'>"
-        "<i>%ΔYTD compares YTD to same period last year; %Δ12mo compares most reent 12 months to 12 months before that.</i></td></tr>"
+        "<i>%ΔYTD compares YTD to same period last year; %Δ12mo compares most recent 12 months to 12 months before that.</i></td></tr>"
     )
 
     print("</table>")

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -512,11 +512,11 @@ def totals_table(conn: sqlite3.Connection):
 
     total_columns = 4 + len(display_day_keys)
     explanation_text = (
-        "%Δ YTD compares this year's totals from Jan 1 through today, to the equivalent period last calendar year.<br> "
-        "%Δ 12mo compares the 12 months from this date last year through today, to the twelve months before that."
+        "&nbsp;&nbsp;%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.<br> "
+        "&nbsp;&nbsp;%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td colspan='{total_columns}' style='text-align:center;font-style:italic;padding-top:6px;'>"
+        f"<tr><td colspan='{total_columns}' style='text-align:left;font-style:italic;padding-top:6px;'>"
         f"{explanation_text}</td></tr>"
     )
 

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -518,8 +518,8 @@ def totals_table(conn: sqlite3.Connection):
     print(
         f"<tr><td colspan='{total_columns}'>"
         "<i>%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.</i></td></tr>"
-        # f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;'>"
-        # "<i>%Δ 12mo compares the 12 months prior to today, to the 12 months before that.</i></td></tr>"
+        f"<tr><td colspan='{total_columns}'>"
+        "<i>%Δ 12mo compares the 12 months prior to today, to the 12 months before that.</i></td></tr>"
     )
 
     print("</table>")

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -516,7 +516,7 @@ def totals_table(conn: sqlite3.Connection):
         "&nbsp;&nbsp;%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;font-size:0.8rem;'>"
+        f"<tr><td colspan='{total_columns}' styleZZZ='text-align:left;padding-top:6px;font-size:0.8rem;'>"
         f"<i>{explanation_text}</i></td></tr>"
     )
 

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -516,7 +516,7 @@ def totals_table(conn: sqlite3.Connection):
         "&nbsp;&nbsp;%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td colspan='{total_columns}' style='text-align:left;font-style:italic;padding-top:6px;'>"
+        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;'>"
         f"{explanation_text}</td></tr>"
     )
 

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -516,8 +516,8 @@ def totals_table(conn: sqlite3.Connection):
         "%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td colspan='{total_columns}'>"
-        "<i>%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.</i></td></tr>"
+        #f"<tr><td colspan='{total_columns}'>"
+        #"<i>%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.</i></td></tr>"
         f"<tr><td colspan='{total_columns}'>"
         "<i>%Δ 12mo compares the 12 months prior to today, to the 12 months before that.</i></td></tr>"
     )

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -516,7 +516,7 @@ def totals_table(conn: sqlite3.Connection):
         "%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;'>"
+        f"<tr><td colspan='{total_columns}'>"
         "<i>%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.</i></td></tr>"
         f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;'>"
         "<i>%Δ 12mo compares the 12 months prior to today, to the 12 months before that.</i></td></tr>"

--- a/web/web_season_report.py
+++ b/web/web_season_report.py
@@ -512,11 +512,11 @@ def totals_table(conn: sqlite3.Connection):
 
     total_columns = 4 + len(display_day_keys)
     explanation_text = (
-        "&nbsp;&nbsp;%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.<br> "
-        "&nbsp;&nbsp;%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
+        "%Δ YTD compares this calendar year from Jan 1 through today, to the same period last year.  "
+        "%Δ 12mo compares the 12 months prior to today, to the 12 months before that."
     )
     print(
-        f"<tr><td colspan='{total_columns}' styleZZZ='text-align:left;padding-top:6px;font-size:0.8rem;'>"
+        f"<tr><td colspan='{total_columns}' style='text-align:left;padding-top:6px;font-size:0.8rem;'>"
         f"<i>{explanation_text}</i></td></tr>"
     )
 


### PR DESCRIPTION
Painful!  Bottom (footer) row of summary table (main page) shows in larger font than the rest of the text, on some browsers (e.g. Brave on mobile).  Happens if:
- text includes < br > tag and colspan is > 4, or
- there is more than one table row of the footer
Solution ("solution"!! ha!) was to shorten the text to a single line, short enough that it does not widen the table.